### PR TITLE
Add contributing instructions

### DIFF
--- a/.ddev/commands/web/init-typo3
+++ b/.ddev/commands/web/init-typo3
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2086
+set -e
+
+## Description: Initialize TYPO3 installation
+## Usage: init-typo3
+## Example: ddev init-typo3
+
+readonly dbHost="db"
+readonly dbUser="db"
+readonly dbPassword="db"
+readonly dbName="db"
+readonly dbCredentials="-h${dbHost} -u${dbUser} -p${dbPassword}"
+readonly fixturePath="/var/www/html/Tests/Fixtures"
+readonly typo3Binary="/var/www/html/vendor/bin/typo3"
+readonly typo3cmsBinary="/var/www/html/vendor/bin/typo3cms"
+
+function _progress() {
+    printf "%s... " "$1"
+}
+
+function _done() {
+    printf "\e[32mDone\e[39m\n"
+}
+
+# Create empty database
+_progress "Creating empty database"
+mysql -Nse "SHOW TABLES" $dbCredentials "$dbName" | while read -r table; do
+    mysql -e "DROP TABLE ${table}" $dbCredentials "$dbName"
+done
+_done
+
+# Prepare setup environment
+export TYPO3_DB_DRIVER=mysqli
+export TYPO3_DB_USERNAME="$dbUser"
+export TYPO3_DB_PASSWORD="$dbPassword"
+export TYPO3_DB_PORT=3306
+export TYPO3_DB_HOST="$dbHost"
+export TYPO3_DB_DBNAME="$dbName"
+export TYPO3_SETUP_ADMIN_EMAIL=admin@example.com
+export TYPO3_SETUP_ADMIN_USERNAME=admin
+export TYPO3_SETUP_ADMIN_PASSWORD=Passw0rd!
+export TYPO3_SERVER_TYPE=other
+export TYPO3_PROJECT_NAME="EXT:bw_focuspoint_images"
+
+# Set up environment
+_progress "Setting up TYPO3 installation"
+  "$typo3Binary" setup --no-interaction --force --quiet
+_done
+
+# Import DB fixtures
+for file in "$fixturePath"/*.sql; do
+    _progress "Importing DB fixture \"$(basename "$file")\""
+    mysql $dbCredentials "$dbName" < "$file"
+    _done
+done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing
+
+Thanks for considering contributing to this extension!
+
+For development, we use [DDEV](https://ddev.readthedocs.io/en/stable/). Set it up before continuing. The setup creates a database and installs TYPO3. This way you can start developing immediately.
+
+## Preparation
+
+```bash
+# Clone repository
+git clone git@github.com:maikschneider/bw_focuspoint_images.git
+cd bw_focuspoint_images
+
+# Start DDEV project
+ddev start
+
+# Install dependencies
+ddev composer install
+ddev npm i
+
+# Setup TYPO3 with a prefilled database
+ddev init-typo3
+
+# Watch assets during development
+ddev npm start
+```
+
+You can access the DDEV site at <https://bw-focuspoint-images.ddev.site/typo3/>.
+To login you can use the username `admin` and password `Passw0rd!`.
+
+## Code analysis and linters
+
+```bash
+# All static code analyzers
+ddev composer sca
+
+# Specific linters
+ddev composer editorconfig:lint
+ddev composer php:lint
+ddev composer typoscript:lint
+ddev composer xml:lint
+ddev composer yaml:lint
+ddev composer php:stan
+
+# Fix specific issues
+ddev composer php:fixer
+ddev composer composer:normalize
+```
+
+## Submit a pull request
+
+Thanks for contributing!
+
+Once you have finished your work, please **submit a pull request** and describe
+what you've done. Ideally, your PR references an issue describing the problem
+you're trying to solve.
+
+All described code quality tools are automatically executed on each pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for considering contributing to this extension!
 
-For development, we use [DDEV](https://ddev.readthedocs.io/en/stable/). Set it up before continuing. The setup creates a database and installs TYPO3. This way you can start developing immediately.
+For development, we use [DDEV](https://ddev.readthedocs.io/en/stable/). Set it up before continuing.
 
 ## Preparation
 
@@ -21,28 +21,26 @@ ddev npm i
 # Setup TYPO3 with a prefilled database
 ddev init-typo3
 
-# Watch assets during development
+# Compile and watch assets during development
 ddev npm start
 ```
 
-You can access the DDEV site at <https://bw-focuspoint-images.ddev.site/typo3/>.
-To login you can use the username `admin` and password `Passw0rd!`.
+You can access the TYPO3 backend at <https://bw-focuspoint-images.ddev.site/typo3/>.
+To login, you can use the username `admin` and password `Passw0rd!`.
 
 ## Code analysis and linters
 
 ```bash
-# All static code analyzers
+# Run all static code analyzers + fixers
 ddev composer sca
 
-# Specific linters
+# Run only a specific linter
 ddev composer editorconfig:lint
 ddev composer php:lint
 ddev composer typoscript:lint
 ddev composer xml:lint
 ddev composer yaml:lint
 ddev composer php:stan
-
-# Fix specific issues
 ddev composer php:fixer
 ddev composer composer:normalize
 ```

--- a/README.md
+++ b/README.md
@@ -211,4 +211,6 @@ Contribute
 
 This extension was made by Maik Schneider: Feel free to contribute!
 
+Please have a look at [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
 Thanks to [blueways](https://www.blueways.de/) and [XIMA](https://www.xima.de/)!

--- a/Tests/Fixtures/example1.tsconfig
+++ b/Tests/Fixtures/example1.tsconfig
@@ -1,0 +1,31 @@
+mod.tx_bwfocuspointimages.settings.fields {
+
+  name {
+    title = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.name
+    type = text
+    useAsName = 1
+  }
+
+  description {
+    title = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.description
+    type = textarea
+  }
+
+  color {
+    title = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.color
+    type = select
+    options {
+      red = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.color.red
+      green = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.color.green
+      blue = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.color.blue
+    }
+    default = red
+  }
+
+  link {
+    title = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.link
+    type = link
+    displayCond = FIELD:color:=:red
+  }
+
+}

--- a/Tests/Fixtures/pages.sql
+++ b/Tests/Fixtures/pages.sql
@@ -1,0 +1,30 @@
+insert into `pages` (`uid`, `pid`, `title`, `slug`, `sys_language_uid`, `l10n_parent`, `l10n_source`, `perms_userid`,
+										 `perms_groupid`, `perms_user`, `perms_group`, `perms_everybody`, `doktype`, `is_siteroot`, `TSconfig`)
+values (1, 0, 'Main', '/', 0, 0, 0, 1, 1, 31, 31, 1, 1, 1, 'mod.tx_bwfocuspointimages.settings.fields {
+                                                                name {
+                                                                    title = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.name
+                                                                    type = text
+                                                                    useAsName = 1
+                                                                }
+
+                                                                description {
+                                                                    title = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.description
+                                                                    type = textarea
+                                                                }
+
+                                                                color {
+                                                                    title = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.color
+                                                                    type = select
+                                                                    options {
+                                                                        red = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.color.red
+                                                                        green = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.color.green
+                                                                        blue = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.color.blue
+                                                                    }
+                                                                }
+
+                                                                link {
+                                                                    title = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.link
+                                                                    type = link
+                                                                }
+
+                                                            }');

--- a/Tests/Fixtures/pages.sql
+++ b/Tests/Fixtures/pages.sql
@@ -1,30 +1,30 @@
 insert into `pages` (`uid`, `pid`, `title`, `slug`, `sys_language_uid`, `l10n_parent`, `l10n_source`, `perms_userid`,
 										 `perms_groupid`, `perms_user`, `perms_group`, `perms_everybody`, `doktype`, `is_siteroot`, `TSconfig`)
 values (1, 0, 'Main', '/', 0, 0, 0, 1, 1, 31, 31, 1, 1, 1, 'mod.tx_bwfocuspointimages.settings.fields {
-                                                                name {
-                                                                    title = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.name
-                                                                    type = text
-                                                                    useAsName = 1
-                                                                }
+																																name {
+																																		title = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.name
+																																		type = text
+																																		useAsName = 1
+																																}
 
-                                                                description {
-                                                                    title = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.description
-                                                                    type = textarea
-                                                                }
+																																description {
+																																		title = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.description
+																																		type = textarea
+																																}
 
-                                                                color {
-                                                                    title = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.color
-                                                                    type = select
-                                                                    options {
-                                                                        red = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.color.red
-                                                                        green = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.color.green
-                                                                        blue = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.color.blue
-                                                                    }
-                                                                }
+																																color {
+																																		title = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.color
+																																		type = select
+																																		options {
+																																				red = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.color.red
+																																				green = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.color.green
+																																				blue = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.color.blue
+																																		}
+																																}
 
-                                                                link {
-                                                                    title = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.link
-                                                                    type = link
-                                                                }
+																																link {
+																																		title = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.link
+																																		type = link
+																																}
 
-                                                            }');
+																														}');

--- a/Tests/Fixtures/pages.sql
+++ b/Tests/Fixtures/pages.sql
@@ -1,30 +1,3 @@
 insert into `pages` (`uid`, `pid`, `title`, `slug`, `sys_language_uid`, `l10n_parent`, `l10n_source`, `perms_userid`,
 										 `perms_groupid`, `perms_user`, `perms_group`, `perms_everybody`, `doktype`, `is_siteroot`, `TSconfig`)
-values (1, 0, 'Main', '/', 0, 0, 0, 1, 1, 31, 31, 1, 1, 1, 'mod.tx_bwfocuspointimages.settings.fields {
-																																name {
-																																		title = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.name
-																																		type = text
-																																		useAsName = 1
-																																}
-
-																																description {
-																																		title = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.description
-																																		type = textarea
-																																}
-
-																																color {
-																																		title = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.color
-																																		type = select
-																																		options {
-																																				red = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.color.red
-																																				green = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.color.green
-																																				blue = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.color.blue
-																																		}
-																																}
-
-																																link {
-																																		title = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.link
-																																		type = link
-																																}
-
-																														}');
+values (1, 0, 'Main', '/', 0, 0, 0, 1, 1, 31, 31, 1, 1, 1, '@import "EXT:bw_focuspoint_images/Tests/Fixtures/example1.tsconfig"');

--- a/Tests/Fixtures/sys_template.sql
+++ b/Tests/Fixtures/sys_template.sql
@@ -1,0 +1,2 @@
+insert into `sys_template` (`uid`, `pid`, `title`, `root`, `clear`, `include_static_file`)
+values (1, 1, 'MAIN TEMPLATE', 1, 3, 'EXT:bootstrap_package/Configuration/TypoScript,EXT:bw_focuspoint_images/Configuration/TypoScript');


### PR DESCRIPTION
This PR adds a contributing guide for new developers. It also adds a init command for TYPO3 to get started with local development. It installs TYPO3 and sets up a basic database with some prefilled fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an automated utility that streamlines TYPO3 installation by setting up the database and configuring the environment.
  
- **Documentation**
  - Added comprehensive contribution guidelines outlining the development setup, dependency installation, and asset handling.
  - Updated project documentation to direct users to these contribution best practices.

- **Tests**
  - Included enhanced sample data for configuring focus point image settings to support improved testing of the wizard interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->