### PR TITLE
Remove not needed TypoScript setup

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -22,23 +22,15 @@ ExtensionManagementUtility::addTcaSelectItem(
 // set palettes and input fields
 $GLOBALS['TCA']['tt_content']['types']['bw_focuspoint_images_svg'] = [
     'showitem' => '
-        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
-            --palette--;;general,
-            --palette--;;headers,
-            assets,
-        --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.appearance,
-            --palette--;;frames,
-            --palette--;;appearanceLinks,
-        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
-            --palette--;;language,
-        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,
-            --palette--;;hidden,
-            --palette--;;access,
-        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:categories,
-            categories,
-        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:notes,
-            rowDescription,
-        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended,
+         --palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xml:palette.general;general,
+        --palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.headers;headers,
+         assets,
+     --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
+        --palette--;;language,
+      --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xml:tabs.access,
+         --palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xml:palette.visibility;visibility,
+         --palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xml:palette.access;access,
+      --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xml:tabs.extended
     ',
     'previewRenderer' => FocuspointPreviewRenderer::class,
 ];

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -22,15 +22,23 @@ ExtensionManagementUtility::addTcaSelectItem(
 // set palettes and input fields
 $GLOBALS['TCA']['tt_content']['types']['bw_focuspoint_images_svg'] = [
     'showitem' => '
-         --palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xml:palette.general;general,
-        --palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.headers;headers,
-         assets,
-     --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
-        --palette--;;language,
-      --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xml:tabs.access,
-         --palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xml:palette.visibility;visibility,
-         --palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xml:palette.access;access,
-      --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xml:tabs.extended
+        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
+            --palette--;;general,
+            --palette--;;headers,
+            assets,
+        --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.appearance,
+            --palette--;;frames,
+            --palette--;;appearanceLinks,
+        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
+            --palette--;;language,
+        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,
+            --palette--;;hidden,
+            --palette--;;access,
+        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:categories,
+            categories,
+        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:notes,
+            rowDescription,
+        --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended,
     ',
     'previewRenderer' => FocuspointPreviewRenderer::class,
 ];

--- a/ext_typoscript_setup.typoscript
+++ b/ext_typoscript_setup.typoscript
@@ -1,8 +1,0 @@
-plugin.tx_bwfocuspointimages.view {
-  templateRootPaths.0 = EXT:bw_focuspoint_images/Resources/Private/Templates/
-  templateRootPaths.1 = {$plugin.tx_bwfocuspointimages.view.templateRootPath}
-  partialRootPaths.0 = EXT:bw_focuspoint_images/Resources/Private/Partials/
-  partialRootPaths.1 = {$plugin.tx_bwfocuspointimages.view.partialRootPath}
-  layoutRootPaths.0 = EXT:bw_focuspoint_images/Resources/Private/Layouts/
-  layoutRootPaths.1 = {$plugin.tx_bwfocuspointimages.view.layoutRootPath}
-}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,11 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Access to an undefined property object\\:\\:\\$uid\\.$#"
+			count: 1
+			path: Classes/DataProcessing/FocuspointProcessor.php
+
+		-
 			message: "#^If condition is always true\\.$#"
 			count: 2
 			path: Classes/Utility/HelperUtility.php


### PR DESCRIPTION
@coderabbitai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Removed legacy configuration for image rendering.
  - As a result, image-based content may display differently. Users might notice changes in how image elements appear within the application.
  - Added a new error message to be ignored in error reporting, which may enhance clarity in development feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->