### PR TITLE
Remove global content element registration

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -1,0 +1,9 @@
+<?php
+
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+ExtensionManagementUtility::registerPageTSConfigFile(
+    'bw_focuspoint_images',
+    'Configuration/TsConfig/Page/newContentElement.tsconfig',
+    'Bw Focuspoint Images Content Element',
+);

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -7,5 +7,5 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 ExtensionManagementUtility::registerPageTSConfigFile(
     'bw_focuspoint_images',
     'Configuration/TsConfig/Page/newContentElement.tsconfig',
-    'Bw Focuspoint Images Content Element',
+    'Focuspoint Images: Content Element',
 );

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -1,5 +1,7 @@
 <?php
 
+defined('TYPO3') || die();
+
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
 ExtensionManagementUtility::registerPageTSConfigFile(

--- a/Configuration/TCA/Overrides/sys_file_reference.php
+++ b/Configuration/TCA/Overrides/sys_file_reference.php
@@ -18,5 +18,3 @@ $additionalColumns = [
 ];
 
 ExtensionManagementUtility::addTCAcolumns('sys_file_reference', $additionalColumns);
-
-//$GLOBALS['TCA']['sys_file_reference']['palettes']['imageoverlayPalette']['showitem'] = 'focus_points';

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -14,6 +14,8 @@ ExtensionManagementUtility::addTcaSelectItem(
         'LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:tca.wizard.svg.title',
         'bw_focuspoint_images_svg', // ctype value
         'bw_focuspoint_images_svg', // icon-identifier
+        'default', // group
+        'LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:tca.wizard.svg.description', // description
     ],
     'textmedia', // position in select box (=after textmedia)
     'after'

--- a/Configuration/TsConfig/Page/newContentElement.tsconfig
+++ b/Configuration/TsConfig/Page/newContentElement.tsconfig
@@ -1,0 +1,20 @@
+# Remove the exclusion of the bw_focuspoint_images_svg content element from the new content element wizard
+mod.wizards.newContentElement.wizardItems {
+  default.removeItems := removeFromList(bw_focuspoint_images_svg)
+}
+
+# Register content element in common tab of the new content element wizard
+mod.wizards.newContentElement.wizardItems.common {
+  elements {
+    bw_focuspoint_images_svg {
+      iconIdentifier = bw_focuspoint_images_svg
+      title = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:tca.wizard.svg.title
+      description = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:tca.wizard.svg.description
+      tt_content_defValues {
+        CType = bw_focuspoint_images_svg
+      }
+    }
+  }
+
+  show := addToList(bw_focuspoint_images_svg)
+}

--- a/Configuration/page.tsconfig
+++ b/Configuration/page.tsconfig
@@ -7,17 +7,6 @@ mod.tx_bwfocuspointimages.settings {
   }
 }
 
-mod.wizards.newContentElement.wizardItems.common {
-  elements {
-    bw_focuspoint_images_svg {
-      iconIdentifier = bw_focuspoint_images_svg
-      title = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:tca.wizard.svg.title
-      description = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:tca.wizard.svg.description
-      tt_content_defValues {
-        CType = bw_focuspoint_images_svg
-      }
-    }
-  }
-
-  show := addToList(bw_focuspoint_images_svg)
+mod.wizards.newContentElement.wizardItems {
+  default.removeItems := addToList(bw_focuspoint_images_svg)
 }

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For administrators
 3.  Include PageTS
 
     Add the static PageTS template **Bw Focuspoint Images Content Element** or manually
-    import the PageTS in your sitepackage:
+    import the PageTS into your sitepackage:
 
     ```typoscript
     @import 'EXT:bw_focuspoint_images/Configuration/TsConfig/Page/newContentElement.tsconfig'

--- a/README.md
+++ b/README.md
@@ -42,7 +42,16 @@ For administrators
     **static TypoScript template** or manually include setup and
     constants.
 
-3.  Define your own wizard fields
+3.  Include PageTS
+
+    Add the static PageTS template **Bw Focuspoint Images Content Element** or manually
+    import the PageTS in your sitepackage:
+
+    ```typoscript
+    @import 'EXT:bw_focuspoint_images/Configuration/TsConfig/Page/newContentElement.tsconfig'
+    ```
+
+4.  Define your own wizard fields
 
     There are **no default fields** defined! An example with working
     frontend output can be found in the PageTS section.

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -98,8 +98,8 @@
 				<target>Oberstes Fenster</target>
 			</trans-unit>
 			<trans-unit id="tca.wizard.svg.title">
-				<source>SVG Focuspoints</source>
-				<target>SVG Fokuspunkte</target>
+				<source>Image with focus points</source>
+				<target>Bild mit Fokuspunkten</target>
 			</trans-unit>
 			<trans-unit id="tca.wizard.svg.description">
 				<source>Displays the focus points of an image using SVG</source>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -76,7 +76,7 @@
 				<source>Top</source>
 			</trans-unit>
 			<trans-unit id="tca.wizard.svg.title">
-				<source>Image with Focuspoints</source>
+				<source>Image with focus points</source>
 			</trans-unit>
 			<trans-unit id="tca.wizard.svg.description">
 				<source>Displays an image with highlighted areas and additional information</source>

--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,9 @@
 		"friendsofphp/php-cs-fixer": "^3.6.0",
 		"helhum/typo3-console": "^8.2",
 		"helmich/typo3-typoscript-lint": "^3.3",
-		"nikic/php-parser": "4.19.4 as 5.3.1",
-		"saschaegerer/phpstan-typo3": "^1.10",
-		"ssch/typo3-rector": "^1.2",
+		"nikic/php-parser": "^4.19 || ^5.5",
+		"saschaegerer/phpstan-typo3": "^1.10 || ^2.1",
+		"ssch/typo3-rector": "^1.2 || ^3.3",
 		"symfony/translation": "^7.2",
 		"typo3/cms-base-distribution": "^12.4 || ^13.4",
 		"typo3/cms-lowlevel": "^12.4 || ^13.4"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,11 +1,25 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Access to an undefined property object\\:\\:\\$uid\\.$#"
+			message: '#^Dead catch \- TYPO3\\CMS\\Core\\Resource\\Exception\\FileDoesNotExistException is never thrown in the try block\.$#'
+			identifier: catch.neverThrown
 			count: 1
-			path: Classes/DataProcessing/FocuspointProcessor.php
+			path: Classes/Utility/HelperUtility.php
 
 		-
-			message: "#^If condition is always true\\.$#"
+			message: '#^Dead catch \- TYPO3\\CMS\\Core\\Resource\\Exception\\FolderDoesNotExistException is never thrown in the try block\.$#'
+			identifier: catch.neverThrown
+			count: 1
+			path: Classes/Utility/HelperUtility.php
+
+		-
+			message: '#^Dead catch \- TYPO3\\CMS\\Core\\Resource\\Exception\\InvalidPathException is never thrown in the try block\.$#'
+			identifier: catch.neverThrown
+			count: 1
+			path: Classes/Utility/HelperUtility.php
+
+		-
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
 			count: 2
 			path: Classes/Utility/HelperUtility.php


### PR DESCRIPTION
The content element is no longer registered globally. From now on, the element needs to be included via PageTS manually. This makes it possible to use the extension in multiple site installations without the need to remove the element in unwanted sites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Registered a new Page TSconfig file to enhance content element configuration.
- **Bug Fixes**
  - Improved metadata and grouping for the "Image with focus points" content element in the content element wizard.
- **Documentation**
  - Updated installation instructions in the README to clarify the inclusion of PageTS configuration.
  - Refined translation strings for better clarity in both English and German.
- **Chores**
  - Broadened development dependency version constraints for improved compatibility.
  - Updated static analysis configuration to address and refine ignored error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->