### PR TITLE
feat: add configurable focus point shapes

### DIFF
--- a/Classes/Preview/FocuspointPreviewRenderer.php
+++ b/Classes/Preview/FocuspointPreviewRenderer.php
@@ -153,37 +153,113 @@ class FocuspointPreviewRenderer extends StandardContentPreviewRenderer
             <mask id="mask' . $fileReference->getUid() . '"><rect x="0" y="0" width="200" height="200" fill="#FFF" fill-opacity="0.5" />';
 
         foreach ($points as $point) {
-            $x = $point->x * 100;
-            $y = $point->y * 100;
-            $height = $point->height * 100;
-            $width = $point->width * 100;
-
-            $svg .= '<rect x="' . $x . '%"
-                y="' . $y . '%"
-                width="' . $width . '%"
-                height="' . $height . '%"
-                fill="#000"/>';
+            $svg .= $this->renderMaskShape($point);
         }
 
         $svg .= '</mask>';
         $svg .= '<rect x="0" y="0" width="200" height="200" fill="#000" mask="url(#mask' . $fileReference->getUid() . ')" />';
 
         foreach ($points as $point) {
-            $x = $point->x * 100;
-            $y = $point->y * 100;
-            $height = $point->height * 100;
-            $width = $point->width * 100;
-
-            $svg .= '<rect x="' . $x . '%"
-                y="' . $y . '%"
-                stroke="#ff8700"
-                stroke-width="1.5px"
-                width="' . $width . '%"
-                height="' . $height . '%"
-                fill="none"/>';
+            $svg .= $this->renderOutlineShape($point);
         }
 
         $svg .= '</svg>';
         return $svg;
+    }
+
+    private function renderMaskShape(object $point): string
+    {
+        $shape = $point->shape ?? 'rectangle';
+
+        return match ($shape) {
+            'circle', 'ellipse' => $this->renderEllipse($point, 'fill="#000"'),
+            'line' => $this->renderLine($point, 'stroke="#000" stroke-width="4" stroke-linecap="round"'),
+            'crosshair' => $this->renderCrosshair($point, 'stroke="#000" stroke-width="4" stroke-linecap="round"'),
+            default => $this->renderRectangle($point, 'fill="#000"'),
+        };
+    }
+
+    private function renderOutlineShape(object $point): string
+    {
+        $shape = $point->shape ?? 'rectangle';
+
+        return match ($shape) {
+            'circle', 'ellipse' => $this->renderEllipse($point, 'stroke="#ff8700" stroke-width="1.5px" fill="none"'),
+            'line' => $this->renderLine($point, 'stroke="#ff8700" stroke-width="2" stroke-linecap="round" fill="none"'),
+            'crosshair' => $this->renderCrosshair($point, 'stroke="#ff8700" stroke-width="2" stroke-linecap="round" fill="none"'),
+            default => $this->renderRectangle($point, 'stroke="#ff8700" stroke-width="1.5px" fill="none"'),
+        };
+    }
+
+    private function renderRectangle(object $point, string $attributes): string
+    {
+        $x = ($point->x ?? 0) * 100;
+        $y = ($point->y ?? 0) * 100;
+        $width = ($point->width ?? 0) * 100;
+        $height = ($point->height ?? 0) * 100;
+
+        return '<rect x="' . $x . '%"
+        y="' . $y . '%"
+        width="' . $width . '%"
+        height="' . $height . '%"
+        ' . $attributes . '/>';
+    }
+
+    private function renderEllipse(object $point, string $attributes): string
+    {
+        $x = ($point->x ?? 0) * 100;
+        $y = ($point->y ?? 0) * 100;
+        $width = ($point->width ?? 0) * 100;
+        $height = ($point->height ?? 0) * 100;
+
+        $cx = $x + ($width / 2);
+        $cy = $y + ($height / 2);
+        $rx = $width / 2;
+        $ry = $height / 2;
+
+        return '<ellipse cx="' . $cx . '%"
+        cy="' . $cy . '%"
+        rx="' . $rx . '%"
+        ry="' . $ry . '%"
+        ' . $attributes . '/>';
+    }
+
+    private function renderLine(object $point, string $attributes): string
+    {
+        $x1 = ($point->x ?? 0) * 100;
+        $y1 = ($point->y ?? 0) * 100;
+
+        $x2 = isset($point->x2)
+            ? $point->x2 * 100
+            : $x1 + (($point->width ?? 0.2) * 100);
+
+        $y2 = isset($point->y2)
+            ? $point->y2 * 100
+            : $y1 + (($point->height ?? 0.2) * 100);
+
+        return '<line x1="' . $x1 . '%"
+        y1="' . $y1 . '%"
+        x2="' . $x2 . '%"
+        y2="' . $y2 . '%"
+        ' . $attributes . '/>';
+    }
+
+    private function renderCrosshair(object $point, string $attributes): string
+    {
+        $x = ($point->x ?? 0) * 100;
+        $y = ($point->y ?? 0) * 100;
+
+        $size = 5;
+
+        return '<line x1="' . ($x - $size) . '%"
+            y1="' . $y . '%"
+            x2="' . ($x + $size) . '%"
+            y2="' . $y . '%"
+            ' . $attributes . '/>
+        <line x1="' . $x . '%"
+            y1="' . ($y - $size) . '%"
+            x2="' . $x . '%"
+            y2="' . ($y + $size) . '%"
+            ' . $attributes . '/>';
     }
 }

--- a/Configuration/Sets/BwFocuspointImagesExample/page.tsconfig
+++ b/Configuration/Sets/BwFocuspointImagesExample/page.tsconfig
@@ -1,5 +1,17 @@
 mod.tx_bwfocuspointimages.settings.fields {
 
+   shape {
+      title = Shape
+      type = shape
+      options {
+        rectangle = Rectangle
+        circle = Circle
+        line = Line
+        crosshair = Crosshair
+      }
+      default = rectangle
+  }
+
   name {
     title = LLL:EXT:bw_focuspoint_images/Resources/Private/Language/locallang_db.xlf:wizard.fields.name
     type = text

--- a/Configuration/Sets/BwFocuspointImagesExample/page.tsconfig
+++ b/Configuration/Sets/BwFocuspointImagesExample/page.tsconfig
@@ -1,6 +1,6 @@
 mod.tx_bwfocuspointimages.settings.fields {
 
-   shape {
+  shape {
       title = Shape
       type = shape
       options {

--- a/Configuration/page.tsconfig
+++ b/Configuration/page.tsconfig
@@ -2,6 +2,7 @@ mod.tx_bwfocuspointimages.settings {
   resizable = 1
   defaultWidth = 0.2
   defaultHeight = 0.2
+  enabledShapes = rectangle
   fields {
 
   }

--- a/Configuration/page.tsconfig
+++ b/Configuration/page.tsconfig
@@ -2,10 +2,7 @@ mod.tx_bwfocuspointimages.settings {
   resizable = 1
   defaultWidth = 0.2
   defaultHeight = 0.2
-  enabledShapes = rectangle
   fields {
-
-  }
 }
 
 mod.wizards.newContentElement.wizardItems {

--- a/Resources/Private/JavaScript/components/Fields/Shape.svelte
+++ b/Resources/Private/JavaScript/components/Fields/Shape.svelte
@@ -1,0 +1,126 @@
+<script>
+    import {focuspoints} from '../../store.svelte.js'
+
+    let {config, index, name} = $props()
+    let options = Object.entries(config.options).map(([value, label]) => ({value, label}))
+
+    function clamp(value) {
+        return Math.max(0, Math.min(1, value))
+    }
+
+    function selectShape(value) {
+        focuspoints.update((items) => items.map((focuspoint, currentIndex) => {
+            if (currentIndex !== index) {
+                return focuspoint
+            }
+
+            if (value === 'crosshair' && focuspoint.shape !== 'crosshair') {
+                return {
+                    ...focuspoint,
+                    [name]: value,
+                    x: clamp((focuspoint.x ?? 0) + ((focuspoint.width ?? 0) / 2)),
+                    y: clamp((focuspoint.y ?? 0) + ((focuspoint.height ?? 0) / 2)),
+                }
+            }
+
+            return {
+                ...focuspoint,
+                [name]: value,
+            }
+        }))
+    }
+</script>
+
+<div class="form-group">
+    <label class="form-label" id="input-{index}-{name}-label">
+        {config.title}
+    </label>
+
+    <div
+        class="shape-select"
+        role="radiogroup"
+        aria-labelledby="input-{index}-{name}-label"
+    >
+        {#each options as {value, label}}
+            <button
+                type="button"
+                class="shape-select__button"
+                class:shape-select__button--active={$focuspoints[index][name] === value}
+                aria-pressed={$focuspoints[index][name] === value}
+                title={label}
+                onclick={(event) => {
+                    event.preventDefault()
+                    selectShape(value)
+                }}
+            >
+                <span class="shape-select__icon" aria-hidden="true">
+                    {#if value === 'rectangle'}
+                        <svg viewBox="0 0 24 24">
+                            <rect x="4" y="6" width="16" height="12" />
+                        </svg>
+                    {:else if value === 'circle' || value === 'ellipse'}
+                        <svg viewBox="0 0 24 24">
+                            <ellipse cx="12" cy="12" rx="8" ry="6" />
+                        </svg>
+                    {:else if value === 'line'}
+                        <svg viewBox="0 0 24 24">
+                            <line x1="5" y1="19" x2="19" y2="5" />
+                        </svg>
+                    {:else if value === 'crosshair'}
+                        <svg viewBox="0 0 24 24">
+                            <line x1="12" y1="4" x2="12" y2="20" />
+                            <line x1="4" y1="12" x2="20" y2="12" />
+                        </svg>
+                    {:else}
+                        {label}
+                    {/if}
+                </span>
+
+                <span class="shape-select__label">
+                    {label}
+                </span>
+            </button>
+        {/each}
+    </div>
+</div>
+
+<style>
+    .shape-select {
+        display: flex;
+        gap: 0.5rem;
+    }
+
+    .shape-select__button {
+        display: flex;
+        flex: 1 1 0;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 0.25rem;
+        min-height: 4rem;
+        padding: 0.5rem;
+        border: 1px solid var(--typo3-component-border-color);
+        border-radius: var(--typo3-component-border-radius);
+        background: var(--typo3-component-bg);
+        color: inherit;
+        cursor: pointer;
+    }
+
+    .shape-select__button:hover,
+    .shape-select__button--active {
+        border-color: var(--typo3-state-primary-bg);
+        box-shadow: inset 0 0 0 1px var(--typo3-state-primary-bg);
+    }
+
+    .shape-select__icon svg {
+        width: 1.5rem;
+        height: 1.5rem;
+        fill: none;
+        stroke: currentColor;
+        stroke-width: 2;
+    }
+
+    .shape-select__label {
+        font-size: 0.75rem;
+    }
+</style>

--- a/Resources/Private/JavaScript/components/Image.svelte
+++ b/Resources/Private/JavaScript/components/Image.svelte
@@ -2,6 +2,9 @@
     import interact from 'interactjs';
     import {activateFocuspoint, focusPointName, focuspoints} from "../store.svelte";
     import {onDestroy, onMount} from "svelte";
+    import FocuspointShape from "./Shapes/FocuspointShape.svelte";
+
+    import {initFocuspointInteractions} from "../interactions/focuspointInteractions";
 
     let {image} = $props()
     let canvasHeight = $state(0)
@@ -10,6 +13,8 @@
     let img
     let initialized = $state(false)
     let isDarkMode = $state(false)
+
+    let cleanupFocuspointInteractions
 
     // Handle keyboard navigation
     function handleKeyDown(event) {
@@ -39,6 +44,11 @@
                 movePoint(activeIndex, step, 0);
                 break;
         }
+    }
+
+    // Helper function to clamps a value to the normalized range between 0 and 1.
+    function clamp(value) {
+        return Math.max(0, Math.min(1, value))
     }
 
     // Helper function to move a point by x,y pixels
@@ -109,6 +119,110 @@
                 }
             }
         })
+    interact('.line-handle')
+        .draggable({
+            modifiers: [
+                interact.modifiers.restrictRect({
+                    restriction: 'parent',
+                    endOnly: false,
+                }),
+            ],
+            listeners: {
+                start(event) {
+                    const index = parseInt(event.target.getAttribute('data-index'), 10)
+
+                    if (Number.isNaN(index)) {
+                        return
+                    }
+
+                    activateFocuspoint(index)
+                },
+                move(event) {
+                    const index = parseInt(event.target.getAttribute('data-index'), 10)
+                    const handle = event.target.getAttribute('data-handle')
+
+                    if (Number.isNaN(index) || !handle || canvasWidth <= 0 || canvasHeight <= 0) {
+                        return
+                    }
+
+                    focuspoints.update((items) => items.map((point, currentIndex) => {
+                        if (currentIndex !== index) {
+                            return point
+                        }
+
+                        const fallbackX2 = clamp((point.x ?? 0) + (point.width ?? 0.2))
+                        const fallbackY2 = clamp((point.y ?? 0) + (point.height ?? 0.2))
+
+                        const currentX = handle === 'start'
+                            ? (point.x ?? 0) * canvasWidth
+                            : (point.x2 ?? fallbackX2) * canvasWidth
+
+                        const currentY = handle === 'start'
+                            ? (point.y ?? 0) * canvasHeight
+                            : (point.y2 ?? fallbackY2) * canvasHeight
+
+                        const nextX = clamp((currentX + event.dx) / canvasWidth)
+                        const nextY = clamp((currentY + event.dy) / canvasHeight)
+
+                        if (handle === 'start') {
+                            return {
+                                ...point,
+                                x: nextX,
+                                y: nextY,
+                            }
+                        }
+
+                        return {
+                            ...point,
+                            x2: nextX,
+                            y2: nextY,
+                        }
+                    }))
+                },
+            },
+        })
+    interact('.crosshair-handle')
+        .draggable({
+            modifiers: [
+                interact.modifiers.restrictRect({
+                    restriction: 'parent',
+                    endOnly: false,
+                }),
+            ],
+            listeners: {
+                start(event) {
+                    const index = parseInt(event.target.getAttribute('data-index'), 10)
+
+                    if (Number.isNaN(index)) {
+                        return
+                    }
+
+                    activateFocuspoint(index)
+                },
+                move(event) {
+                    const index = parseInt(event.target.getAttribute('data-index'), 10)
+
+                    if (Number.isNaN(index) || canvasWidth <= 0 || canvasHeight <= 0) {
+                        return
+                    }
+
+                    focuspoints.update((items) => items.map((point, currentIndex) => {
+                        if (currentIndex !== index) {
+                            return point
+                        }
+
+                        const currentX = (point.x ?? 0) * canvasWidth
+                        const currentY = (point.y ?? 0) * canvasHeight
+
+                        return {
+                            ...point,
+                            x: clamp((currentX + event.dx) / canvasWidth),
+                            y: clamp((currentY + event.dy) / canvasHeight),
+                        }
+                    }))
+                },
+            },
+        })
 
     onMount(() => {
         if (img.complete) {
@@ -116,6 +230,14 @@
         } else {
             img.addEventListener('load', setCanvasSizes)
         }
+        cleanupFocuspointInteractions = initFocuspointInteractions({
+            focuspoints,
+            activateFocuspoint,
+            getCanvasDimensions: () => ({
+                canvasWidth,
+                canvasHeight,
+            }),
+        })
 
         window.addEventListener('resize', updateCanvasSizes)
         window.addEventListener('keydown', handleKeyDown)
@@ -164,34 +286,7 @@
 </script>
 
 <style>
-    .draggable {
-        position: absolute;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        transition: opacity 0.15s ease;
-        user-select: none;
-    }
 
-    .style1 {
-        display: inline-grid;
-        background-color: rgba(0, 0, 0, 0.6);
-        border: 1px dashed rgba(255, 255, 255, 0.8);
-        color: white;
-        padding: 10px;
-        --typo3-state-primary-bg: rgba(255, 255, 255, 0.8);
-    }
-
-    .opacity-0 {
-        opacity: 0;
-    }
-
-    .style1.active {
-        border-color: #ff8700;
-        --typo3-state-primary-bg: #ff8700;
-        border-style: solid;
-        background-color: rgba(0, 0, 0, 0.8);
-    }
 
     img {
         pointer-events: none;
@@ -219,44 +314,27 @@
     }
 
     .wrapper {
+        position: relative;
         align-self: center;
     }
 
-    .ui-resizable-handle.ui-resizable-nw, .ui-resizable-handle.ui-resizable-ne {
-        top: -3px;
-    }
 
-    .ui-resizable-handle.ui-resizable-sw, .ui-resizable-handle.ui-resizable-se {
-        bottom: -3px;
-    }
-
-    .ui-resizable-handle.ui-resizable-ne, .ui-resizable-handle.ui-resizable-se {
-        right: -3px;
-    }
-
-    .ui-resizable-handle.ui-resizable-nw, .ui-resizable-handle.ui-resizable-sw {
-        left: -3px;
-    }
 </style>
 
 <div class="cropper-bg" class:cropper-bg--dark={isDarkMode} touch-action="none">
     <div class="wrapper">
         {#each $focuspoints as focuspoint, index}
-            <div
-                onclick={() => activateFocuspoint(index)}
-                class:active={focuspoint.active}
-                class:opacity-0={!initialized}
-                data-index={index}
-                class="draggable style1 resizable"
-                style="transform:translate3d({getPositionX(index)}px, {getPositionY(index)}px, 0); width: {getFocuspointWidth(index)}px; height: {getFocuspointHeight(index)}px;"
-                data-x="{getPositionX(index)}"
-                data-y="{getPositionY(index)}">
-                <span class="text-break">{focuspointName(focuspoint, index)}</span>
-                <span class="ui-resizable-handle ui-resizable-nw"></span>
-                <span class="ui-resizable-handle ui-resizable-ne"></span>
-                <span class="ui-resizable-handle ui-resizable-sw"></span>
-                <span class="ui-resizable-handle ui-resizable-se"></span>
-            </div>
+            <FocuspointShape
+                {focuspoint}
+                {index}
+                {initialized}
+                {canvasWidth}
+                {canvasHeight}
+                {getPositionX}
+                {getPositionY}
+                {getFocuspointWidth}
+                {getFocuspointHeight}
+            />
         {/each}
         <img bind:this={img} src={image} alt="Selected" unselectable="on" />
     </div>

--- a/Resources/Private/JavaScript/components/Preview.svelte
+++ b/Resources/Private/JavaScript/components/Preview.svelte
@@ -1,8 +1,54 @@
 <script>
     let {image, points, itemFormElName} = $props()
 
-    function percentage(number) {
-        return number * 100 + '%'
+    function percentage(number, fallback = 0) {
+        const parsedNumber = Number(number)
+
+        return (Number.isFinite(parsedNumber) ? parsedNumber : fallback) * 100 + '%'
+    }
+
+    function shapeOf(point) {
+        return point.shape ?? 'rectangle'
+    }
+
+    function ellipseCx(point) {
+        return ((Number(point.x) || 0) + ((Number(point.width) || 0) / 2)) * 100 + '%'
+    }
+
+    function ellipseCy(point) {
+        return ((Number(point.y) || 0) + ((Number(point.height) || 0) / 2)) * 100 + '%'
+    }
+
+    function ellipseRx(point) {
+        return ((Number(point.width) || 0) / 2) * 100 + '%'
+    }
+
+    function ellipseRy(point) {
+        return ((Number(point.height) || 0) / 2) * 100 + '%'
+    }
+
+    function lineX2(point) {
+        return percentage(point.x2 ?? ((point.x ?? 0) + (point.width ?? 0.2)))
+    }
+
+    function lineY2(point) {
+        return percentage(point.y2 ?? ((point.y ?? 0) + (point.height ?? 0.2)))
+    }
+
+    function crosshairLeft(point) {
+        return `calc(${percentage(point.x)} - 5%)`
+    }
+
+    function crosshairRight(point) {
+        return `calc(${percentage(point.x)} + 5%)`
+    }
+
+    function crosshairTop(point) {
+        return `calc(${percentage(point.y)} - 5%)`
+    }
+
+    function crosshairBottom(point) {
+        return `calc(${percentage(point.y)} + 5%)`
     }
 </script>
 
@@ -34,28 +80,111 @@
 <div class="wrapper">
     <div class="preview">
         <img src={image} alt="Preview" />
+
         <svg viewBox="0 0 200 200" preserveAspectRatio="none" class="focuspoint__svg" xmlns="http://www.w3.org/2000/svg">
             <mask id="mask{itemFormElName}">
                 <rect x="0" y="0" width="200" height="200" fill="#FFF" fill-opacity="0.5" />
+
                 {#each points as point}
+                    {@const shape = shapeOf(point)}
+
+                    {#if shape === 'ellipse' || shape === 'circle'}
+                        <ellipse
+                            cx={ellipseCx(point)}
+                            cy={ellipseCy(point)}
+                            rx={ellipseRx(point)}
+                            ry={ellipseRy(point)}
+                            fill="#000" />
+                    {:else if shape === 'line'}
+                        <line
+                            x1={percentage(point.x)}
+                            y1={percentage(point.y)}
+                            x2={lineX2(point)}
+                            y2={lineY2(point)}
+                            stroke="#000"
+                            stroke-width="4"
+                            stroke-linecap="round" />
+                    {:else if shape === 'crosshair'}
+                        <line
+                            x1={crosshairLeft(point)}
+                            y1={percentage(point.y)}
+                            x2={crosshairRight(point)}
+                            y2={percentage(point.y)}
+                            stroke="#000"
+                            stroke-width="4"
+                            stroke-linecap="round" />
+                        <line
+                            x1={percentage(point.x)}
+                            y1={crosshairTop(point)}
+                            x2={percentage(point.x)}
+                            y2={crosshairBottom(point)}
+                            stroke="#000"
+                            stroke-width="4"
+                            stroke-linecap="round" />
+                    {:else}
+                        <rect
+                            x={percentage(point.x)}
+                            y={percentage(point.y)}
+                            width={percentage(point.width)}
+                            height={percentage(point.height)}
+                            fill="#000" />
+                    {/if}
+                {/each}
+            </mask>
+
+            <rect x="0" y="0" width="200" height="200" fill="#000" mask="url(#mask{itemFormElName})" />
+
+            {#each points as point}
+                {@const shape = shapeOf(point)}
+
+                {#if shape === 'ellipse' || shape === 'circle'}
+                    <ellipse
+                        cx={ellipseCx(point)}
+                        cy={ellipseCy(point)}
+                        rx={ellipseRx(point)}
+                        ry={ellipseRy(point)}
+                        stroke="#ff8700"
+                        stroke-width="1.5px"
+                        fill="none" />
+                {:else if shape === 'line'}
+                    <line
+                        x1={percentage(point.x)}
+                        y1={percentage(point.y)}
+                        x2={lineX2(point)}
+                        y2={lineY2(point)}
+                        stroke="#ff8700"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        fill="none" />
+                {:else if shape === 'crosshair'}
+                    <line
+                        x1={crosshairLeft(point)}
+                        y1={percentage(point.y)}
+                        x2={crosshairRight(point)}
+                        y2={percentage(point.y)}
+                        stroke="#ff8700"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        fill="none" />
+                    <line
+                        x1={percentage(point.x)}
+                        y1={crosshairTop(point)}
+                        x2={percentage(point.x)}
+                        y2={crosshairBottom(point)}
+                        stroke="#ff8700"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        fill="none" />
+                {:else}
                     <rect
                         x={percentage(point.x)}
                         y={percentage(point.y)}
                         width={percentage(point.width)}
                         height={percentage(point.height)}
-                        fill="#000" />
-                {/each}
-            </mask>
-            <rect x="0" y="0" width="200" height="200" fill="#000" mask="url(#mask{itemFormElName})" />
-            {#each points as point}
-                <rect
-                    x={percentage(point.x)}
-                    y={percentage(point.y)}
-                    width={percentage(point.width)}
-                    height={percentage(point.height)}
-                    stroke="#ff8700"
-                    stroke-width="1.5px"
-                    fill="none" />
+                        stroke="#ff8700"
+                        stroke-width="1.5px"
+                        fill="none" />
+                {/if}
             {/each}
         </svg>
     </div>

--- a/Resources/Private/JavaScript/components/Shapes/Crosshair.svelte
+++ b/Resources/Private/JavaScript/components/Shapes/Crosshair.svelte
@@ -1,0 +1,103 @@
+<script>
+    import {activateFocuspoint} from '../../store.svelte.js'
+
+    let {
+        focuspoint,
+        index,
+        initialized,
+        canvasWidth,
+        canvasHeight
+    } = $props()
+
+    const size = 22
+
+    function getX() {
+        return (focuspoint?.x ?? 0) * canvasWidth
+    }
+
+    function getY() {
+        return (focuspoint?.y ?? 0) * canvasHeight
+    }
+</script>
+
+<svg
+    class="focuspoint-crosshair"
+    class:active={focuspoint?.active}
+    class:opacity-0={!initialized}
+    width={canvasWidth}
+    height={canvasHeight}
+    aria-hidden="true"
+>
+    <line
+        x1={getX() - size}
+        y1={getY()}
+        x2={getX() + size}
+        y2={getY()}
+    />
+    <line
+        x1={getX()}
+        y1={getY() - size}
+        x2={getX()}
+        y2={getY() + size}
+    />
+</svg>
+
+<button
+    type="button"
+    class="crosshair-handle"
+    class:active={focuspoint?.active}
+    class:opacity-0={!initialized}
+    data-index={index}
+    style="transform: translate3d({getX()}px, {getY()}px, 0) translate(-50%, -50%);"
+    onclick={(event) => {
+        event.preventDefault()
+        activateFocuspoint(index)
+    }}
+    aria-label="Move crosshair point"
+></button>
+
+<style>
+    .focuspoint-crosshair {
+        position: absolute;
+        inset: 0;
+        overflow: visible;
+        pointer-events: none;
+        transition: opacity 0.15s ease;
+    }
+
+    .focuspoint-crosshair line {
+        stroke: rgba(255, 255, 255, 0.95);
+        stroke-width: 2;
+        stroke-linecap: round;
+        vector-effect: non-scaling-stroke;
+    }
+
+    .focuspoint-crosshair.active line {
+        stroke: #ff8700;
+    }
+
+    .crosshair-handle {
+        position: absolute;
+        z-index: 5;
+        width: 14px;
+        height: 14px;
+        padding: 0;
+        border: 2px solid rgba(255, 255, 255, 0.95);
+        border-radius: 50%;
+        background: rgba(0, 0, 0, 0.8);
+        cursor: grab;
+        transition: opacity 0.15s ease, border-color 0.15s ease;
+    }
+
+    .crosshair-handle.active {
+        border-color: #ff8700;
+    }
+
+    .crosshair-handle:active {
+        cursor: grabbing;
+    }
+
+    .opacity-0 {
+        opacity: 0;
+    }
+</style>

--- a/Resources/Private/JavaScript/components/Shapes/Ellipse.svelte
+++ b/Resources/Private/JavaScript/components/Shapes/Ellipse.svelte
@@ -1,0 +1,23 @@
+<script>
+    import Rectangle from './Rectangle.svelte'
+
+    let {
+        focuspoint,
+        index,
+        initialized,
+        getPositionX,
+        getPositionY,
+        getFocuspointWidth,
+        getFocuspointHeight
+    } = $props()
+</script>
+
+<Rectangle
+    {focuspoint}
+    {index}
+    {initialized}
+    {getPositionX}
+    {getPositionY}
+    {getFocuspointWidth}
+    {getFocuspointHeight}
+/>

--- a/Resources/Private/JavaScript/components/Shapes/FocuspointShape.svelte
+++ b/Resources/Private/JavaScript/components/Shapes/FocuspointShape.svelte
@@ -1,0 +1,48 @@
+<script>
+    import {focuspoints} from '../../store.svelte.js'
+    import Rectangle from './Rectangle.svelte'
+    import Ellipse from './Ellipse.svelte'
+    import Line from './Line.svelte'
+    import Crosshair from "./Crosshair.svelte";
+
+    let {
+        index,
+        initialized,
+        canvasWidth,
+        canvasHeight,
+        getPositionX,
+        getPositionY,
+        getFocuspointWidth,
+        getFocuspointHeight
+    } = $props()
+
+    const components = {
+        rectangle: Rectangle,
+        ellipse: Ellipse,
+        circle: Ellipse,
+        line: Line,
+        crosshair: Crosshair,
+    }
+
+    let focuspoint = $derived($focuspoints[index])
+    let shape = $derived(focuspoint?.shape ?? 'rectangle')
+    let Component = $derived(components[shape] ?? Rectangle)
+</script>
+
+{#if focuspoint}
+    {#key shape}
+        <!-- svelte-ignore svelte_component_deprecated -->
+        <svelte:component
+            this={Component}
+            {focuspoint}
+            {index}
+            {initialized}
+            {canvasWidth}
+            {canvasHeight}
+            {getPositionX}
+            {getPositionY}
+            {getFocuspointWidth}
+            {getFocuspointHeight}
+        />
+    {/key}
+{/if}

--- a/Resources/Private/JavaScript/components/Shapes/Line.svelte
+++ b/Resources/Private/JavaScript/components/Shapes/Line.svelte
@@ -1,0 +1,157 @@
+<script>
+    import {activateFocuspoint, focuspoints} from '../../store.svelte.js'
+
+    let {
+        focuspoint,
+        index,
+        initialized,
+        canvasWidth,
+        canvasHeight
+    } = $props()
+
+    function clamp(value) {
+        return Math.max(0, Math.min(1, value))
+    }
+
+    function getFallbackEndX() {
+        return clamp((focuspoint?.x ?? 0) + (focuspoint?.width ?? 0.2))
+    }
+
+    function getFallbackEndY() {
+        return clamp((focuspoint?.y ?? 0) + (focuspoint?.height ?? 0.2))
+    }
+
+    function getStartX() {
+        return (focuspoint?.x ?? 0) * canvasWidth
+    }
+
+    function getStartY() {
+        return (focuspoint?.y ?? 0) * canvasHeight
+    }
+
+    function getEndX() {
+        return (focuspoint?.x2 ?? getFallbackEndX()) * canvasWidth
+    }
+
+    function getEndY() {
+        return (focuspoint?.y2 ?? getFallbackEndY()) * canvasHeight
+    }
+
+    function ensureLineEndPoint() {
+        if (!focuspoint) {
+            return
+        }
+
+        if (focuspoint.x2 !== undefined && focuspoint.y2 !== undefined) {
+            return
+        }
+
+        focuspoints.update((items) => items.map((item, currentIndex) => {
+            if (currentIndex !== index) {
+                return item
+            }
+
+            return {
+                ...item,
+                x2: item.x2 ?? clamp((item.x ?? 0) + (item.width ?? 0.2)),
+                y2: item.y2 ?? clamp((item.y ?? 0) + (item.height ?? 0.2)),
+            }
+        }))
+    }
+
+    $effect(() => {
+        ensureLineEndPoint()
+    })
+</script>
+
+<svg
+    class="focuspoint-line"
+    class:active={focuspoint?.active}
+    class:opacity-0={!initialized}
+    aria-hidden="true"
+>
+    <line
+        x1={getStartX()}
+        y1={getStartY()}
+        x2={getEndX()}
+        y2={getEndY()}
+    />
+</svg>
+
+<button
+    type="button"
+    class="line-handle"
+    class:active={focuspoint?.active}
+    class:opacity-0={!initialized}
+    data-index={index}
+    data-handle="start"
+    style="transform: translate3d({getStartX()}px, {getStartY()}px, 0) translate(-50%, -50%);"
+    onclick={(event) => {
+        event.preventDefault()
+        activateFocuspoint(index)
+    }}
+    aria-label="Move line start point"
+></button>
+
+<button
+    type="button"
+    class="line-handle"
+    class:active={focuspoint?.active}
+    class:opacity-0={!initialized}
+    data-index={index}
+    data-handle="end"
+    style="transform: translate3d({getEndX()}px, {getEndY()}px, 0) translate(-50%, -50%);"
+    onclick={(event) => {
+        event.preventDefault()
+        activateFocuspoint(index)
+    }}
+    aria-label="Move line end point"
+></button>
+
+<style>
+    .focuspoint-line {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        overflow: visible;
+        pointer-events: none;
+        transition: opacity 0.15s ease;
+    }
+
+    .focuspoint-line line {
+        stroke: rgba(255, 255, 255, 0.9);
+        stroke-width: 3;
+        stroke-linecap: round;
+        vector-effect: non-scaling-stroke;
+    }
+
+    .focuspoint-line.active line {
+        stroke: #ff8700;
+    }
+
+    .line-handle {
+        position: absolute;
+        z-index: 5;
+        width: 14px;
+        height: 14px;
+        padding: 0;
+        border: 2px solid rgba(255, 255, 255, 0.9);
+        border-radius: 50%;
+        background: rgba(0, 0, 0, 0.8);
+        cursor: grab;
+        transition: opacity 0.15s ease, border-color 0.15s ease;
+    }
+
+    .line-handle.active {
+        border-color: #ff8700;
+    }
+
+    .line-handle:active {
+        cursor: grabbing;
+    }
+
+    .opacity-0 {
+        opacity: 0;
+    }
+</style>

--- a/Resources/Private/JavaScript/components/Shapes/Rectangle.svelte
+++ b/Resources/Private/JavaScript/components/Shapes/Rectangle.svelte
@@ -1,0 +1,88 @@
+<script>
+    import {activateFocuspoint, focusPointName} from '../../store.svelte.js'
+
+    let {
+        focuspoint,
+        index,
+        initialized,
+        getPositionX,
+        getPositionY,
+        getFocuspointWidth,
+        getFocuspointHeight
+    } = $props()
+
+    let focuspointName = $derived((focuspoint, index) => focusPointName(index))
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+    onclick={() => activateFocuspoint(index)}
+    class:active={focuspoint.active}
+    class:opacity-0={!initialized}
+    data-index={index}
+    class="draggable style1 resizable focuspoint-shape focuspoint-shape--{focuspoint.shape ?? 'rectangle'}"
+    style="transform:translate3d({getPositionX(index)}px, {getPositionY(index)}px, 0); width: {getFocuspointWidth(index)}px; height: {getFocuspointHeight(index)}px;"
+    data-x="{getPositionX(index)}"
+    data-y="{getPositionY(index)}"
+>
+    <span class="text-break">{focuspointName(focuspoint, index)}</span>
+
+    <span class="ui-resizable-handle ui-resizable-nw"></span>
+    <span class="ui-resizable-handle ui-resizable-ne"></span>
+    <span class="ui-resizable-handle ui-resizable-sw"></span>
+    <span class="ui-resizable-handle ui-resizable-se"></span>
+</div>
+
+<style>
+
+    .focuspoint-shape--ellipse,
+    .focuspoint-shape--circle {
+        border-radius: 50%;
+    }
+
+    .draggable {
+        position: absolute;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        transition: opacity 0.15s ease;
+        user-select: none;
+    }
+
+    .style1 {
+        display: inline-grid;
+        background-color: rgba(0, 0, 0, 0.6);
+        border: 1px dashed rgba(255, 255, 255, 0.8);
+        color: white;
+        padding: 10px;
+        --typo3-state-primary-bg: rgba(255, 255, 255, 0.8);
+    }
+
+    .opacity-0 {
+        opacity: 0;
+    }
+
+    .style1.active {
+        border-color: #ff8700;
+        --typo3-state-primary-bg: #ff8700;
+        border-style: solid;
+        background-color: rgba(0, 0, 0, 0.8);
+    }
+
+    .ui-resizable-handle.ui-resizable-nw, .ui-resizable-handle.ui-resizable-ne {
+        top: -3px;
+    }
+
+    .ui-resizable-handle.ui-resizable-sw, .ui-resizable-handle.ui-resizable-se {
+        bottom: -3px;
+    }
+
+    .ui-resizable-handle.ui-resizable-ne, .ui-resizable-handle.ui-resizable-se {
+        right: -3px;
+    }
+
+    .ui-resizable-handle.ui-resizable-nw, .ui-resizable-handle.ui-resizable-sw {
+        left: -3px;
+    }
+</style>

--- a/Resources/Private/JavaScript/components/Sidebar.svelte
+++ b/Resources/Private/JavaScript/components/Sidebar.svelte
@@ -14,6 +14,7 @@
     import Textarea from "./Fields/Textarea.svelte";
     import Link from "./Fields/Link.svelte";
     import Checkbox from "./Fields/Checkbox.svelte";
+    import Shape from "./Fields/Shape.svelte";
 
     onMount(() => {
         getIcon('actions-chevron-up')
@@ -32,7 +33,8 @@
         textarea: Textarea,
         select: Select,
         link: Link,
-        checkbox: Checkbox
+        checkbox: Checkbox,
+        shape: Shape
     };
 </script>
 

--- a/Resources/Private/JavaScript/interactions/focuspointInteractions.js
+++ b/Resources/Private/JavaScript/interactions/focuspointInteractions.js
@@ -113,10 +113,10 @@ const initRectangleInteraction = ({
 }
 
 const initLineInteraction = ({
-                               focuspoints,
-                               activateFocuspoint,
-                               getCanvasDimensions,
-                             }) => {
+                              focuspoints,
+                              activateFocuspoint,
+                              getCanvasDimensions,
+                            }) => {
   interact('.line-handle')
     .draggable({
       modifiers: [
@@ -231,10 +231,10 @@ const initCrosshairInteraction = ({
 }
 
 export const initFocuspointInteractions = ({
-                                             focuspoints,
-                                             activateFocuspoint,
-                                             getCanvasDimensions,
-                                           }) => {
+                                            focuspoints,
+                                            activateFocuspoint,
+                                            getCanvasDimensions,
+                                          }) => {
   const config = {
     focuspoints,
     activateFocuspoint,

--- a/Resources/Private/JavaScript/interactions/focuspointInteractions.js
+++ b/Resources/Private/JavaScript/interactions/focuspointInteractions.js
@@ -1,0 +1,253 @@
+import interact from 'interactjs'
+
+const clamp = (value) => Math.max(0, Math.min(1, value))
+
+const getIndex = (event) => {
+  const index = parseInt(event.target.getAttribute('data-index'), 10)
+
+  return Number.isNaN(index) ? null : index
+}
+
+const getCanvasSize = (getCanvasDimensions) => {
+  const { canvasWidth, canvasHeight } = getCanvasDimensions()
+
+  return {
+    canvasWidth,
+    canvasHeight,
+    isValid: canvasWidth > 0 && canvasHeight > 0,
+  }
+}
+
+const initRectangleInteraction = ({
+                                    focuspoints,
+                                    activateFocuspoint,
+                                    getCanvasDimensions,
+                                  }) => {
+  interact('.draggable')
+    .resizable({
+      edges: { left: true, right: true, bottom: true, top: true },
+      modifiers: [
+        interact.modifiers.restrictEdges({
+          outer: 'parent',
+          endOnly: true,
+        }),
+      ],
+      listeners: {
+        move(event) {
+          const index = getIndex(event)
+          const { canvasWidth, canvasHeight, isValid } = getCanvasSize(getCanvasDimensions)
+
+          if (index === null || !isValid) {
+            return
+          }
+
+          focuspoints.update((items) => items.map((point, currentIndex) => {
+            if (currentIndex !== index) {
+              return point
+            }
+
+            const x = ((point.x ?? 0) * canvasWidth) + event.deltaRect.left
+            const y = ((point.y ?? 0) * canvasHeight) + event.deltaRect.top
+
+            return {
+              ...point,
+              width: event.rect.width / canvasWidth,
+              height: event.rect.height / canvasHeight,
+              x: clamp(x / canvasWidth),
+              y: clamp(y / canvasHeight),
+            }
+          }))
+        },
+
+        end(event) {
+          const index = getIndex(event)
+
+          if (index !== null) {
+            activateFocuspoint(index)
+          }
+        },
+      },
+    })
+    .draggable({
+      modifiers: [
+        interact.modifiers.restrictRect({
+          restriction: 'parent',
+          endOnly: true,
+        }),
+      ],
+      autoScroll: true,
+      listeners: {
+        move(event) {
+          const index = getIndex(event)
+          const { canvasWidth, canvasHeight, isValid } = getCanvasSize(getCanvasDimensions)
+
+          if (index === null || !isValid) {
+            return
+          }
+
+          focuspoints.update((items) => items.map((point, currentIndex) => {
+            if (currentIndex !== index) {
+              return point
+            }
+
+            const x = ((point.x ?? 0) * canvasWidth) + event.dx
+            const y = ((point.y ?? 0) * canvasHeight) + event.dy
+
+            return {
+              ...point,
+              x: clamp(x / canvasWidth),
+              y: clamp(y / canvasHeight),
+            }
+          }))
+        },
+
+        end(event) {
+          const index = getIndex(event)
+
+          if (index !== null) {
+            activateFocuspoint(index)
+          }
+        },
+      },
+    })
+}
+
+const initLineInteraction = ({
+                               focuspoints,
+                               activateFocuspoint,
+                               getCanvasDimensions,
+                             }) => {
+  interact('.line-handle')
+    .draggable({
+      modifiers: [
+        interact.modifiers.restrictRect({
+          restriction: 'parent',
+          endOnly: false,
+        }),
+      ],
+      listeners: {
+        start(event) {
+          const index = getIndex(event)
+
+          if (index !== null) {
+            activateFocuspoint(index)
+          }
+        },
+
+        move(event) {
+          const index = getIndex(event)
+          const handle = event.target.getAttribute('data-handle')
+          const { canvasWidth, canvasHeight, isValid } = getCanvasSize(getCanvasDimensions)
+
+          if (index === null || !handle || !isValid) {
+            return
+          }
+
+          focuspoints.update((items) => items.map((point, currentIndex) => {
+            if (currentIndex !== index) {
+              return point
+            }
+
+            const fallbackX2 = clamp((point.x ?? 0) + (point.width ?? 0.2))
+            const fallbackY2 = clamp((point.y ?? 0) + (point.height ?? 0.2))
+
+            const currentX = handle === 'start'
+              ? (point.x ?? 0) * canvasWidth
+              : (point.x2 ?? fallbackX2) * canvasWidth
+
+            const currentY = handle === 'start'
+              ? (point.y ?? 0) * canvasHeight
+              : (point.y2 ?? fallbackY2) * canvasHeight
+
+            const nextX = clamp((currentX + event.dx) / canvasWidth)
+            const nextY = clamp((currentY + event.dy) / canvasHeight)
+
+            if (handle === 'start') {
+              return {
+                ...point,
+                x: nextX,
+                y: nextY,
+              }
+            }
+
+            return {
+              ...point,
+              x2: nextX,
+              y2: nextY,
+            }
+          }))
+        },
+      },
+    })
+}
+
+const initCrosshairInteraction = ({
+                                    focuspoints,
+                                    activateFocuspoint,
+                                    getCanvasDimensions,
+                                  }) => {
+  interact('.crosshair-handle')
+    .draggable({
+      modifiers: [
+        interact.modifiers.restrictRect({
+          restriction: 'parent',
+          endOnly: false,
+        }),
+      ],
+      listeners: {
+        start(event) {
+          const index = getIndex(event)
+
+          if (index !== null) {
+            activateFocuspoint(index)
+          }
+        },
+
+        move(event) {
+          const index = getIndex(event)
+          const { canvasWidth, canvasHeight, isValid } = getCanvasSize(getCanvasDimensions)
+
+          if (index === null || !isValid) {
+            return
+          }
+
+          focuspoints.update((items) => items.map((point, currentIndex) => {
+            if (currentIndex !== index) {
+              return point
+            }
+
+            const currentX = (point.x ?? 0) * canvasWidth
+            const currentY = (point.y ?? 0) * canvasHeight
+
+            return {
+              ...point,
+              x: clamp((currentX + event.dx) / canvasWidth),
+              y: clamp((currentY + event.dy) / canvasHeight),
+            }
+          }))
+        },
+      },
+    })
+}
+
+export const initFocuspointInteractions = ({
+                                             focuspoints,
+                                             activateFocuspoint,
+                                             getCanvasDimensions,
+                                           }) => {
+  const config = {
+    focuspoints,
+    activateFocuspoint,
+    getCanvasDimensions,
+  }
+
+  initRectangleInteraction(config)
+  initLineInteraction(config)
+  initCrosshairInteraction(config)
+
+  return () => {
+    interact('.draggable').unset()
+    interact('.line-handle').unset()
+    interact('.crosshair-handle').unset()
+  }
+}

--- a/Resources/Private/JavaScript/store.svelte.js
+++ b/Resources/Private/JavaScript/store.svelte.js
@@ -8,7 +8,6 @@ export const focuspoints = writable([]);
 export const focuspointChannelName = (itemFormElName) => `focuspoint:${itemFormElName}`
 
 export const initStores = (initialValue, wizardConfig) => {
-
   const parsedWizardConfig = JSON.parse(wizardConfig)
 
   wizardConfigStore.set({
@@ -106,16 +105,17 @@ export const createNewFocuspoint = () => {
       return acc;
     }, {});
 
+    newFocuspoint.shape ??= 'rectangle'
     // set default values
-  newFocuspoint.shape = 'rectangle'
     newFocuspoint.x = 0.333;
     newFocuspoint.y =  0.333;
     newFocuspoint.width = parseFloat(config.defaultWidth);
     newFocuspoint.height = parseFloat(config.defaultHeight);
 
     // add the new focuspoint to the store and activate it
+    const newFocuspointIndex = get(focuspoints).length
     focuspoints.update(focuspoints => [...focuspoints, newFocuspoint]);
-    activateFocuspoint(get(focuspoints).length - 1);
+    activateFocuspoint(newFocuspointIndex);
 }
 
 export const iconStore = writable({});

--- a/Resources/Private/JavaScript/store.svelte.js
+++ b/Resources/Private/JavaScript/store.svelte.js
@@ -9,7 +9,13 @@ export const focuspointChannelName = (itemFormElName) => `focuspoint:${itemFormE
 
 export const initStores = (initialValue, wizardConfig) => {
     wizardConfigStore.set(JSON.parse(wizardConfig));
-    focuspoints.set(JSON.parse(initialValue && initialValue !== '' ? initialValue : '[]'));
+
+  const initalFocuspoints = JSON.parse(initialValue && initialValue !== '' ? initialValue : '[]').map(focuspoint => ({
+    ...focuspoint,
+    shape: focuspoint.shape ?? 'rectangle'
+  }))
+
+    focuspoints.set(initalFocuspoints);
 }
 
 /**
@@ -95,6 +101,7 @@ export const createNewFocuspoint = () => {
     }, {});
 
     // set default values
+  newFocuspoint.shape = 'rectangle'
     newFocuspoint.x = 0.333;
     newFocuspoint.y =  0.333;
     newFocuspoint.width = parseFloat(config.defaultWidth);

--- a/Resources/Private/JavaScript/store.svelte.js
+++ b/Resources/Private/JavaScript/store.svelte.js
@@ -8,7 +8,13 @@ export const focuspoints = writable([]);
 export const focuspointChannelName = (itemFormElName) => `focuspoint:${itemFormElName}`
 
 export const initStores = (initialValue, wizardConfig) => {
-    wizardConfigStore.set(JSON.parse(wizardConfig));
+
+  const parsedWizardConfig = JSON.parse(wizardConfig)
+
+  wizardConfigStore.set({
+    ...parsedWizardConfig,
+    enabledShapes: parsedWizardConfig.enabledShapes ? parsedWizardConfig.enabledShapes.split(',').map((shape)=>shape.trim()).filter(Boolean) : ['rectangle']
+  })
 
   const initalFocuspoints = JSON.parse(initialValue && initialValue !== '' ? initialValue : '[]').map(focuspoint => ({
     ...focuspoint,

--- a/Resources/Public/Css/FocuspointImage.css
+++ b/Resources/Public/Css/FocuspointImage.css
@@ -1,5 +1,5 @@
 .focuspoint {
-    display: grid;
+    display: inline-grid;
     grid-template-columns: 100%;
     grid-template-rows: auto min-content;
     max-width: 100%;


### PR DESCRIPTION
Adds configurable shape support for focus points.

This introduces a new `shape` field type rendered as an icon-based radio/button group and adds editor support for rectangle, circle/ellipse, line, and crosshair shapes.

The rendering logic was split into dedicated shape components, and the interaction handling was moved into a separate module. Rectangle and ellipse keep the existing draggable/resizable behavior, while line and crosshair use their own point-based interactions.

The preview rendering now respects the selected shape instead of always rendering rectangles.

Existing focus points remain backwards compatible: points without a `shape` value are treated as `rectangle`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Focus points now support multiple shapes: rectangle, ellipse, line, and crosshair
  * Added shape selector to easily configure focus point type
  * Preview rendering now correctly displays and allows editing of all focus point shape types with interactive handles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->